### PR TITLE
Update workflow name and add build status badge to README

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 # This workflow will build a golang project
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
-name: Go
+name: Main
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Geranos
 
+[![Build Status](https://github.com/mobileinf/geranos/actions/workflows/main.yml/badge.svg)](https://github.com/mobileinf/geranos/actions/workflows/main.yml)
+
 In a world where data is as vast as oceans, and speed is the essence of success,
 there emerges a champion for efficiency and innovation: **Geranos**.
 Powered by the robust `go-containerregistry` library,


### PR DESCRIPTION
- Changed the name of the main workflow to "Main" (we will try to keep this convention across all repositories)
- Added build badge to the README

Test Plan:
- Ensure all CI checks pass